### PR TITLE
feat: add chainlink vrf extension to record

### DIFF
--- a/src/extensions.json
+++ b/src/extensions.json
@@ -16,5 +16,11 @@
     "description": "Adds support for Chainlink Data Feeds, including price and other data feeds.",
     "repository": "https://github.com/Arb-Stylus/create-stylus-extensions",
     "branch": "chainlink-data-feed"
+  },
+  {
+    "extensionFlagValue": "chainlink-vrf",
+    "description": "Adds support for Chainlink VRF, including random number generation and randomness.",
+    "repository": "https://github.com/Arb-Stylus/create-stylus-extensions",
+    "branch": "chainlink-vrf"
   }
 ]


### PR DESCRIPTION
# Task name here

Implement chainlink vrf extension.

<img width="1093" height="422" alt="image" src="https://github.com/user-attachments/assets/20db1ca5-8aba-47d7-a9a5-a8062a0d8c7a" />

## Types of change

- [X] Feature
- [ ] Bug
- [ ] Enhancement

## Comments (optional)
