### PR TITLE
fix: regenerate workspace Cargo.lock after extension overlay (contracts/ layout)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import {
   createFirstGitCommit,
   prettierFormat,
   setConfigNetworkToSepolia,
+  refreshCargoLocks,
 } from "./tasks";
 import type { Options } from "./types";
 import { renderOutroMessage } from "./utils/render-outro-message";
@@ -56,6 +57,10 @@ export async function createProject(options: Options) {
             await setConfigNetworkToSepolia(targetDirectory);
           }
         },
+      },
+      {
+        title: `🔒 Refreshing Cargo.lock for contracts`,
+        task: async () => await refreshCargoLocks(targetDirectory),
       },
       {
         title: `📦 Installing dependencies with yarn, this could take a while`,

--- a/src/tasks/copy-template-files.ts
+++ b/src/tasks/copy-template-files.ts
@@ -41,7 +41,7 @@ const copyBaseFiles = async (
       const isYarnLock = isYarnLockRegex.test(fileName);
       const isNextGenerated = isNextGeneratedRegex.test(fileName);
       const isGitKeep = isGitKeepRegex.test(fileName);
-      const isYourContract = /packages\/stylus\/your-contract/.test(fileName);
+      const isYourContract = /packages\/stylus\/contracts\/your-contract/.test(fileName);
 
       // Check if file matches any exclude pattern
       const isExcluded = excludePatterns.some(pattern => pattern.test(fileName));

--- a/src/tasks/index.ts
+++ b/src/tasks/index.ts
@@ -4,3 +4,4 @@ export * from "./install-packages";
 export * from "./create-first-git-commit";
 export * from "./prettier-format";
 export * from "./config-to-sepolia";
+export * from "./refresh-cargo-lock";

--- a/src/tasks/refresh-cargo-lock.ts
+++ b/src/tasks/refresh-cargo-lock.ts
@@ -34,13 +34,10 @@ export async function refreshCargoLocks(targetDir: string) {
   if (!fs.existsSync(stylusDir)) return;
 
   const contractDirs = findContractDirs(stylusDir);
-  const missing = contractDirs.filter(
-    (d) => !fs.existsSync(path.join(d, "Cargo.lock"))
-  );
 
-  if (missing.length === 0) return;
+  if (contractDirs.length === 0) return;
 
-  for (const contractDir of missing) {
+  for (const contractDir of contractDirs) {
     try {
       try {
         await execa(

--- a/src/tasks/refresh-cargo-lock.ts
+++ b/src/tasks/refresh-cargo-lock.ts
@@ -1,0 +1,71 @@
+import { execa } from "execa";
+import fs from "fs";
+import path from "path";
+
+const SKIP_DIRS = new Set([".git", "target", "node_modules", ".cargo"]);
+
+function findContractDirs(dir: string): string[] {
+  const result: string[] = [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return result;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || SKIP_DIRS.has(entry.name)) continue;
+    const fullPath = path.join(dir, entry.name);
+
+    if (fs.existsSync(path.join(fullPath, "Cargo.toml"))) {
+      result.push(fullPath);
+    } else {
+      result.push(...findContractDirs(fullPath));
+    }
+  }
+
+  return result;
+}
+
+export async function refreshCargoLocks(targetDir: string) {
+  const stylusDir = path.join(targetDir, "packages", "stylus");
+
+  if (!fs.existsSync(stylusDir)) return;
+
+  const contractDirs = findContractDirs(stylusDir);
+  const missing = contractDirs.filter(
+    (d) => !fs.existsSync(path.join(d, "Cargo.lock"))
+  );
+
+  if (missing.length === 0) return;
+
+  for (const contractDir of missing) {
+    try {
+      try {
+        await execa(
+          "cargo",
+          ["metadata", "--format-version", "1", "--offline"],
+          { cwd: contractDir, stdio: "pipe" }
+        );
+      } catch {
+        await execa("cargo", ["metadata", "--format-version", "1"], {
+          cwd: contractDir,
+          stdio: "pipe",
+        });
+      }
+    } catch (error: any) {
+      const isNotFound = error?.code === "ENOENT";
+      const label = path.relative(targetDir, contractDir);
+      if (isNotFound) {
+        console.warn(
+          `\n[warn] cargo not found on PATH — skipping Cargo.lock refresh for ${label}`
+        );
+      } else {
+        console.warn(
+          `\n[warn] Could not refresh Cargo.lock for ${label}: ${error?.message ?? error}`
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
---

## ⚠️ MERGE ORDER

**This PR must merge to create-stylus `main` BEFORE the scaffold-stylus parity-pin PR merges.**

A merge to scaffold-stylus `main` auto-syncs scaffold-stylus into `templates/base` AND auto-publishes create-stylus using whatever is in create-stylus `main` `src/` at that moment. If the scaffold-stylus PR lands first, it would publish a broken create-stylus (old path logic, no working lock refresh). **Merge this first.**

## Bug

After scaffolding with an extension (e.g. `create-stylus -e erc-20`), the first `yarn deploy` fails:

```
error: the lock file Cargo.lock needs to be updated but --locked was passed to prevent this
```

`cargo stylus deploy` (0.10.x) builds with `--locked`, which hard-fails on a lock that doesn't match the manifest.

## Root cause

The contracts live in a unified Cargo **workspace** (`packages/stylus/contracts/`) with one shared `Cargo.lock`. An extension overlays a new workspace member (e.g. `erc20-example/`), but nothing regenerates the workspace-root lock — so the shipped `contracts/Cargo.lock` is **stale** (missing the new member) at deploy time.

## Fix

New scaffold task `refreshCargoLocks` (`src/tasks/refresh-cargo-lock.ts`), run once after all extension overlays are applied and before install:

- Finds the contract/workspace dir(s) under `packages/stylus/` and runs a **pin-preserving minimal** lock update: `cargo metadata --format-version 1 --offline`, with an **online fallback** for extensions that introduce a new external crate.
- Never uses `cargo generate-lockfile` / no-arg `cargo update` (those full-re-resolve and would drift pinned deps).
- **Warn-and-continue** on failure; skips gracefully if `cargo` is not on PATH.
- Refreshes the workspace root so a **stale** lock (not just a missing one) is corrected after an overlay adds members.
- Also fixes the `isYourContract` skip regex in `copy-template-files.ts` for the `contracts/` layout (`packages/stylus/contracts/your-contract`).

`parity-scale-codec` is held at `=3.7.5` by the base `contracts/your-contract/Cargo.toml` pin (always-present workspace member), so the minimal update cannot drift it.

## End-to-end evidence (npm link, against the migrated contracts/ workspace template)

- **Repro without fix (Step E):** `-e erc-20` then `cargo metadata --locked` ❌ `the lock file Cargo.lock needs to be updated but --locked was passed`.
- **With fix (Step D):** `-e erc-20` then `cargo metadata --locked` ✅ resolves cleanly.
- **Regression (Step G):** base scaffold (no extension) ✅; `parity-scale-codec = 3.7.5` confirmed in **both** the erc-20 and base generated locks.

> Note: `cargo stylus check --locked` is not valid in cargo-stylus 0.10.2 (the subcommand doesn't accept `--locked`); `cargo metadata --locked` is the lock-validity gate. `cargo stylus check` (WASM) currently fails on a known OZ-sdk VM mismatch unrelated to this fix.

## Status

Open for review — **do not merge yet** (awaiting maintainer review + correct merge ordering above).

---
